### PR TITLE
Bump `reviewdog` to `v0.20.3`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:
-        REVIEWDOG_VERSION: v0.14.1
+        REVIEWDOG_VERSION: v0.20.3
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
Bumps https://github.com/reviewdog/reviewdog to the latest version.

There have been a number of fixes shipped since and we are currently running into https://github.com/reviewdog/reviewdog/issues/1696 (https://github.com/patch-technology/patch/actions/runs/14448146133/job/40513790140#step:15:86), [which was addressed in `v0.17.5`](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#v0175---2024-06-01).